### PR TITLE
Improve WinForms duplicate file finder with progress reporting

### DIFF
--- a/SameFiles.WinForms/DuplicateFile.cs
+++ b/SameFiles.WinForms/DuplicateFile.cs
@@ -1,0 +1,27 @@
+using System.Drawing;
+using System.IO;
+
+namespace SameFiles.WinForms
+{
+    public class DuplicateFile
+    {
+        public string Path { get; }
+        public string Name => System.IO.Path.GetFileName(Path);
+        public long Size { get; }
+        public string Hash { get; }
+        public int GroupCount { get; }
+        public bool Delete { get; set; }
+        public Image? Preview { get; }
+
+        public DuplicateFile(string path, string hash, int groupCount)
+        {
+            Path = path;
+            Hash = hash;
+            GroupCount = groupCount;
+            Size = new FileInfo(path).Length;
+            Preview = ThumbnailProvider.GetThumbnail(path, 96, 96);
+        }
+
+        public string Directory => System.IO.Path.GetDirectoryName(Path) ?? string.Empty;
+    }
+}

--- a/SameFiles.WinForms/DuplicateFinder.cs
+++ b/SameFiles.WinForms/DuplicateFinder.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+
+namespace SameFiles.WinForms
+{
+    public static class DuplicateFinder
+    {
+        public static Task<List<DuplicateFile>> FindDuplicatesAsync(string rootPath, IProgress<ScanProgress>? progress = null)
+            => Task.Run(() => FindDuplicates(rootPath, progress));
+
+        private static List<DuplicateFile> FindDuplicates(string rootPath, IProgress<ScanProgress>? progress)
+        {
+            var result = new List<DuplicateFile>();
+            if (!Directory.Exists(rootPath)) return result;
+
+            var allFiles = EnumerateFilesSafe(rootPath).ToList();
+            var sizeGroups = allFiles.GroupBy(f => new FileInfo(f).Length);
+            int total = allFiles.Count;
+            int scanned = 0;
+            progress?.Report(new ScanProgress(scanned, total));
+
+            var hashGroups = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+            foreach (var sizeGroup in sizeGroups)
+            {
+                if (sizeGroup.Count() < 2)
+                {
+                    scanned += sizeGroup.Count();
+                    progress?.Report(new ScanProgress(scanned, total));
+                    continue;
+                }
+
+                foreach (var file in sizeGroup)
+                {
+                    string hash;
+                    try
+                    {
+                        hash = ComputeHash(file);
+                    }
+                    catch (IOException)
+                    {
+                        scanned++;
+                        progress?.Report(new ScanProgress(scanned, total));
+                        continue;
+                    }
+                    catch (UnauthorizedAccessException)
+                    {
+                        scanned++;
+                        progress?.Report(new ScanProgress(scanned, total));
+                        continue;
+                    }
+
+                    if (!hashGroups.TryGetValue(hash, out var list))
+                    {
+                        list = new List<string>();
+                        hashGroups[hash] = list;
+                    }
+                    list.Add(file);
+
+                    scanned++;
+                    progress?.Report(new ScanProgress(scanned, total));
+                }
+            }
+
+            foreach (var pair in hashGroups)
+            {
+                if (pair.Value.Count > 1)
+                {
+                    var count = pair.Value.Count;
+                    foreach (var file in pair.Value)
+                        result.Add(new DuplicateFile(file, pair.Key, count));
+                }
+            }
+
+            return result;
+        }
+
+        private static IEnumerable<string> EnumerateFilesSafe(string root)
+        {
+            var stack = new Stack<string>();
+            stack.Push(root);
+            while (stack.Count > 0)
+            {
+                var current = stack.Pop();
+                string[] files = Array.Empty<string>();
+                try
+                {
+                    files = Directory.GetFiles(current);
+                }
+                catch (IOException) { }
+                catch (UnauthorizedAccessException) { }
+                foreach (var file in files)
+                    yield return file;
+
+                string[] dirs = Array.Empty<string>();
+                try
+                {
+                    dirs = Directory.GetDirectories(current);
+                }
+                catch (IOException) { }
+                catch (UnauthorizedAccessException) { }
+                foreach (var dir in dirs)
+                    stack.Push(dir);
+            }
+        }
+
+        private static string ComputeHash(string path)
+        {
+            using var sha = SHA256.Create();
+            using var stream = File.OpenRead(path);
+            var hash = sha.ComputeHash(stream);
+            return Convert.ToHexString(hash);
+        }
+    }
+
+    public record ScanProgress(int Scanned, int Total);
+}

--- a/SameFiles.WinForms/MainForm.Designer.cs
+++ b/SameFiles.WinForms/MainForm.Designer.cs
@@ -1,0 +1,133 @@
+namespace SameFiles.WinForms
+{
+    partial class MainForm
+    {
+        private System.ComponentModel.IContainer components = null!;
+        private System.Windows.Forms.TextBox txtFolder = null!;
+        private System.Windows.Forms.Button btnBrowse = null!;
+        private System.Windows.Forms.Button btnScan = null!;
+        private System.Windows.Forms.Button btnDelete = null!;
+        private System.Windows.Forms.ProgressBar progressBar = null!;
+        private System.Windows.Forms.Label lblProgress = null!;
+        private System.Windows.Forms.DataGridView grid = null!;
+        private System.Windows.Forms.DataGridViewCheckBoxColumn colDelete = null!;
+        private System.Windows.Forms.DataGridViewImageColumn colPreview = null!;
+        private System.Windows.Forms.DataGridViewTextBoxColumn colName = null!;
+        private System.Windows.Forms.DataGridViewTextBoxColumn colSize = null!;
+        private System.Windows.Forms.DataGridViewTextBoxColumn colPath = null!;
+        private System.Windows.Forms.DataGridViewButtonColumn colOpen = null!;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            components = new System.ComponentModel.Container();
+            txtFolder = new System.Windows.Forms.TextBox();
+            btnBrowse = new System.Windows.Forms.Button();
+            btnScan = new System.Windows.Forms.Button();
+            btnDelete = new System.Windows.Forms.Button();
+            progressBar = new System.Windows.Forms.ProgressBar();
+            lblProgress = new System.Windows.Forms.Label();
+            grid = new System.Windows.Forms.DataGridView();
+            colDelete = new System.Windows.Forms.DataGridViewCheckBoxColumn();
+            colPreview = new System.Windows.Forms.DataGridViewImageColumn();
+            colName = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colSize = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colPath = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colOpen = new System.Windows.Forms.DataGridViewButtonColumn();
+            ((System.ComponentModel.ISupportInitialize)grid).BeginInit();
+            SuspendLayout();
+            // txtFolder
+            txtFolder.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            txtFolder.Location = new System.Drawing.Point(12, 12);
+            txtFolder.Size = new System.Drawing.Size(400, 23);
+            // btnBrowse
+            btnBrowse.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            btnBrowse.Location = new System.Drawing.Point(418, 11);
+            btnBrowse.Size = new System.Drawing.Size(32, 23);
+            btnBrowse.Text = "...";
+            btnBrowse.Click += btnBrowse_Click;
+            // btnScan
+            btnScan.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            btnScan.Location = new System.Drawing.Point(456, 11);
+            btnScan.Size = new System.Drawing.Size(75, 23);
+            btnScan.Text = "Scan";
+            btnScan.Click += btnScan_Click;
+            // btnDelete
+            btnDelete.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            btnDelete.Location = new System.Drawing.Point(537, 11);
+            btnDelete.Size = new System.Drawing.Size(113, 23);
+            btnDelete.Text = "Delete selected";
+            btnDelete.Enabled = false;
+            btnDelete.Click += btnDelete_Click;
+            // progressBar
+            progressBar.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            progressBar.Location = new System.Drawing.Point(12, 40);
+            progressBar.Size = new System.Drawing.Size(638, 23);
+            // lblProgress
+            lblProgress.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left;
+            lblProgress.Location = new System.Drawing.Point(12, 66);
+            lblProgress.Size = new System.Drawing.Size(200, 15);
+            lblProgress.Text = "0/0";
+            // grid
+            grid.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            grid.Location = new System.Drawing.Point(12, 84);
+            grid.Size = new System.Drawing.Size(638, 354);
+            grid.AllowUserToAddRows = false;
+            grid.AutoGenerateColumns = false;
+            grid.RowTemplate.Height = 96;
+            grid.CellContentClick += grid_CellContentClick;
+            grid.CellValueChanged += grid_CellValueChanged;
+            grid.CurrentCellDirtyStateChanged += grid_CurrentCellDirtyStateChanged;
+            grid.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] { colDelete, colPreview, colName, colSize, colPath, colOpen });
+            // colDelete
+            colDelete.DataPropertyName = "Delete";
+            colDelete.HeaderText = "Delete";
+            colDelete.Width = 50;
+            // colPreview
+            colPreview.DataPropertyName = "Preview";
+            colPreview.HeaderText = "Preview";
+            colPreview.ImageLayout = System.Windows.Forms.DataGridViewImageCellLayout.Zoom;
+            colPreview.Width = 100;
+            // colName
+            colName.DataPropertyName = "Name";
+            colName.HeaderText = "Name";
+            colName.Width = 150;
+            // colSize
+            colSize.DataPropertyName = "Size";
+            colSize.HeaderText = "Size";
+            colSize.Width = 80;
+            // colPath
+            colPath.DataPropertyName = "Directory";
+            colPath.HeaderText = "Path";
+            colPath.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            // colOpen
+            colOpen.HeaderText = "Open";
+            colOpen.Text = "Open";
+            colOpen.UseColumnTextForButtonValue = true;
+            colOpen.Width = 60;
+            // MainForm
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            ClientSize = new System.Drawing.Size(662, 450);
+            Controls.Add(grid);
+            Controls.Add(lblProgress);
+            Controls.Add(progressBar);
+            Controls.Add(btnDelete);
+            Controls.Add(btnScan);
+            Controls.Add(btnBrowse);
+            Controls.Add(txtFolder);
+            Text = "SameFiles";
+            ((System.ComponentModel.ISupportInitialize)grid).EndInit();
+            ResumeLayout(false);
+            PerformLayout();
+        }
+    }
+}

--- a/SameFiles.WinForms/MainForm.cs
+++ b/SameFiles.WinForms/MainForm.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Windows.Forms;
+using System.Threading.Tasks;
+
+namespace SameFiles.WinForms
+{
+    public partial class MainForm : Form
+    {
+        private readonly BindingList<DuplicateFile> _duplicates = new();
+
+        public MainForm()
+        {
+            InitializeComponent();
+            grid.DataSource = _duplicates;
+            btnDelete.Enabled = false;
+        }
+
+        private void btnBrowse_Click(object sender, EventArgs e)
+        {
+            using var dlg = new FolderBrowserDialog();
+            if (dlg.ShowDialog(this) == DialogResult.OK)
+                txtFolder.Text = dlg.SelectedPath;
+        }
+
+        private async void btnScan_Click(object sender, EventArgs e)
+        {
+            btnScan.Enabled = false;
+            btnDelete.Enabled = false;
+            progressBar.Value = 0;
+            lblProgress.Text = "0/0";
+            _duplicates.Clear();
+
+            var progress = new Progress<ScanProgress>(p =>
+            {
+                progressBar.Maximum = p.Total == 0 ? 1 : p.Total;
+                progressBar.Value = Math.Min(p.Scanned, progressBar.Maximum);
+                lblProgress.Text = $"{p.Scanned}/{p.Total}";
+            });
+
+            var files = await DuplicateFinder.FindDuplicatesAsync(txtFolder.Text, progress);
+            foreach (var file in files)
+                _duplicates.Add(file);
+
+            MessageBox.Show(this, $"Scan complete. Found {files.Count} duplicate files.", "Scan", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            btnScan.Enabled = true;
+            UpdateDeleteButton();
+        }
+
+        private void btnDelete_Click(object sender, EventArgs e)
+        {
+            var groups = _duplicates.GroupBy(f => f.Hash);
+            var toRemove = new List<DuplicateFile>();
+            foreach (var group in groups)
+            {
+                var marked = group.Where(f => f.Delete).ToList();
+                if (marked.Count == 0) continue;
+                if (marked.Count >= group.Count()) continue;
+
+                foreach (var file in marked)
+                {
+                    try
+                    {
+                        File.Delete(file.Path);
+                        toRemove.Add(file);
+                    }
+                    catch (IOException)
+                    {
+                        // ignore errors
+                    }
+                    catch (UnauthorizedAccessException)
+                    {
+                        // ignore errors
+                    }
+                }
+            }
+            foreach (var f in toRemove)
+                _duplicates.Remove(f);
+
+            MessageBox.Show(this, $"Deletion complete. Deleted {toRemove.Count} files.", "Delete", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            UpdateDeleteButton();
+        }
+
+        private void grid_CellContentClick(object sender, DataGridViewCellEventArgs e)
+        {
+            if (e.RowIndex < 0) return;
+            if (grid.Columns[e.ColumnIndex] == colOpen)
+            {
+                var file = (DuplicateFile)grid.Rows[e.RowIndex].DataBoundItem;
+                try
+                {
+                    Process.Start("explorer.exe", $"/select,\"{file.Path}\"");
+                }
+                catch (Exception)
+                {
+                }
+            }
+        }
+
+        private void grid_CurrentCellDirtyStateChanged(object sender, EventArgs e)
+        {
+            if (grid.IsCurrentCellDirty)
+                grid.CommitEdit(DataGridViewDataErrorContexts.Commit);
+        }
+
+        private void grid_CellValueChanged(object sender, DataGridViewCellEventArgs e)
+        {
+            if (e.RowIndex < 0) return;
+            if (grid.Columns[e.ColumnIndex] == colDelete)
+            {
+                var file = (DuplicateFile)grid.Rows[e.RowIndex].DataBoundItem;
+                var group = _duplicates.Where(f => f.Hash == file.Hash).ToList();
+                var checkedCount = group.Count(f => f.Delete);
+                if (checkedCount >= group.Count)
+                {
+                    file.Delete = false;
+                    grid.Refresh();
+                }
+                UpdateDeleteButton();
+            }
+        }
+
+        private void UpdateDeleteButton()
+        {
+            btnDelete.Enabled = _duplicates.Any(f => f.Delete);
+        }
+    }
+}

--- a/SameFiles.WinForms/Program.cs
+++ b/SameFiles.WinForms/Program.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Windows.Forms;
+
+namespace SameFiles.WinForms
+{
+    internal static class Program
+    {
+        [STAThread]
+        static void Main()
+        {
+            ApplicationConfiguration.Initialize();
+            Application.Run(new MainForm());
+        }
+    }
+}

--- a/SameFiles.WinForms/SameFiles.WinForms.csproj
+++ b/SameFiles.WinForms/SameFiles.WinForms.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/SameFiles.WinForms/ThumbnailProvider.cs
+++ b/SameFiles.WinForms/ThumbnailProvider.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Drawing;
+using System.Runtime.InteropServices;
+
+namespace SameFiles.WinForms
+{
+    public static class ThumbnailProvider
+    {
+        [DllImport("shell32.dll", CharSet = CharSet.Unicode, PreserveSig = false)]
+        private static extern void SHCreateItemFromParsingName(string path, IntPtr pbc, ref Guid riid, out IShellItemImageFactory ppv);
+
+        [DllImport("gdi32.dll")]
+        private static extern bool DeleteObject(IntPtr hObject);
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct SIZE
+        {
+            public int cx;
+            public int cy;
+        }
+
+        [Flags]
+        private enum SIIGBF
+        {
+            SIIGBF_RESIZETOFIT = 0x00,
+            SIIGBF_BIGGERSIZEOK = 0x01,
+            SIIGBF_MEMORYONLY = 0x02,
+            SIIGBF_ICONONLY = 0x04,
+            SIIGBF_THUMBNAILONLY = 0x08,
+            SIIGBF_INCACHEONLY = 0x10,
+        }
+
+        [ComImport]
+        [Guid("bcc18b79-ba16-442f-80c4-8a59c30c463b")]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        private interface IShellItemImageFactory
+        {
+            void GetImage(SIZE size, SIIGBF flags, out IntPtr phbm);
+        }
+
+        public static Image? GetThumbnail(string path, int width, int height)
+        {
+            try
+            {
+                var guid = typeof(IShellItemImageFactory).GUID;
+                SHCreateItemFromParsingName(path, IntPtr.Zero, ref guid, out var factory);
+                var size = new SIZE { cx = width, cy = height };
+                factory.GetImage(size, SIIGBF.SIIGBF_RESIZETOFIT, out var hBmp);
+                var img = Image.FromHbitmap(hBmp);
+                DeleteObject(hBmp);
+                return img;
+            }
+            catch
+            {
+                try
+                {
+                    using var icon = Icon.ExtractAssociatedIcon(path);
+                    return icon?.ToBitmap();
+                }
+                catch
+                {
+                    return null;
+                }
+            }
+        }
+    }
+}

--- a/SameFiles.sln
+++ b/SameFiles.sln
@@ -1,0 +1,18 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SameFiles.WinForms", "SameFiles.WinForms\SameFiles.WinForms.csproj", "{6A6730E4-5B1C-43E7-A44E-3C5D7FAE7123}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {6A6730E4-5B1C-43E7-A44E-3C5D7FAE7123}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {6A6730E4-5B1C-43E7-A44E-3C5D7FAE7123}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {6A6730E4-5B1C-43E7-A44E-3C5D7FAE7123}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {6A6730E4-5B1C-43E7-A44E-3C5D7FAE7123}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Summary
- show scan progress with total file count, progress bar, and status label
- disable delete until selection and report results after scan and deletion
- handle inaccessible files gracefully while reporting progress

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0c84b3c08329a1cc47a27dc94995